### PR TITLE
Respect `defer-plugin-errors`

### DIFF
--- a/majority-multisign/majority-multisign.cabal
+++ b/majority-multisign/majority-multisign.cabal
@@ -55,7 +55,7 @@ common lang
     -fno-omit-interface-pragmas -fobject-code -fno-strictness
     -fplugin=RecordDotPreprocessor
     
-  if (defer-plugin-errors)
+  if flag(defer-plugin-errors)
     ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
   default-language:   Haskell2010

--- a/majority-multisign/majority-multisign.cabal
+++ b/majority-multisign/majority-multisign.cabal
@@ -3,6 +3,12 @@ name:               majority-multisign
 version:            1.0
 extra-source-files: CHANGELOG.md
 
+flag defer-plugin-errors
+    description:
+        Defer errors from the plugin, useful for things like Haddock that can't handle it.
+    default: False
+    manual: True
+
 common lang
   default-extensions:
     NoImplicitPrelude
@@ -48,6 +54,9 @@ common lang
     -Wmissing-deriving-strategies -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas -fobject-code -fno-strictness
     -fplugin=RecordDotPreprocessor
+    
+  if (defer-plugin-errors)
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
   default-language:   Haskell2010
 


### PR DESCRIPTION
This is to be able to use the project as a build dependency